### PR TITLE
Refactor voice conversation runtime

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -17,6 +17,9 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
+
+      - name: Install Metal Toolchain
+        run: xcodebuild -downloadComponent MetalToolchain
           
       - name: List Available Schemes and Destinations
         run: |

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -1,13 +1,12 @@
-name: iOS Build
-# This workflow runs whenever a PR is made to the main branch
-# It builds the Ichi app for the iOS simulator to check for build errors
+name: App Build
+
 on:
   pull_request:
     branches: [ main ]
 
 jobs:
   build:
-    name: Build iOS App
+    name: Build macOS App
     runs-on: macos-latest
     
     steps:
@@ -30,56 +29,17 @@ jobs:
       - name: Install Dependencies
         run: |
           xcodebuild -resolvePackageDependencies -project Ichi.xcodeproj
-          
-      - name: Build for iOS Simulator
+
+      - name: Run Conversation Tests
+        run: swift test
+
+      - name: Build for macOS
         run: |
-          # Use the generic iOS Simulator destination that's shown as available
-          set +e
           xcodebuild clean build \
             -project Ichi.xcodeproj \
             -scheme Ichi \
-            -destination "generic/platform=iOS Simulator" \
+            -destination "platform=macOS,arch=arm64" \
             -configuration Debug \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO
-          BUILD_STATUS=$?
-          set -e
-          
-          # If the above build fails, try alternative approaches
-          if [ $BUILD_STATUS -ne 0 ]; then
-            echo "Failed to build with generic iOS Simulator destination, trying alternative..."
-            
-            # Try with explicit simulator destination
-            set +e
-            xcodebuild clean build \
-              -project Ichi.xcodeproj \
-              -scheme Ichi \
-              -destination "platform=iOS Simulator,id=dvtdevice-DVTiOSDeviceSimulatorPlaceholder-iphonesimulator:placeholder" \
-              -configuration Debug \
-              CODE_SIGN_IDENTITY="" \
-              CODE_SIGNING_REQUIRED=NO \
-              CODE_SIGNING_ALLOWED=NO
-            BUILD_STATUS=$?
-            set -e
-            
-            # If still failing, try to find and use the first available scheme
-            if [ $BUILD_STATUS -ne 0 ]; then
-              echo "Still failing, trying to determine the correct scheme..."
-              SCHEME=$(xcodebuild -project Ichi.xcodeproj -list | grep -A 10 "Schemes:" | grep -v "Schemes:" | head -1 | xargs)
-              if [ ! -z "$SCHEME" ]; then
-                echo "Building with scheme: $SCHEME"
-                xcodebuild clean build \
-                  -project Ichi.xcodeproj \
-                  -scheme "$SCHEME" \
-                  -destination "generic/platform=iOS Simulator" \
-                  -configuration Debug \
-                  CODE_SIGN_IDENTITY="" \
-                  CODE_SIGNING_REQUIRED=NO \
-                  CODE_SIGNING_ALLOWED=NO
-              else
-                echo "No schemes found, build failed"
-                exit 1
-              fi
-            fi
-          fi

--- a/Ichi.xcodeproj/project.pbxproj
+++ b/Ichi.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0A969CB02DDDD1C400A3DF34 /* Swift-TTS in Frameworks */ = {isa = PBXBuildFile; productRef = 0A969CAF2DDDD1C400A3DF34 /* Swift-TTS */; };
+		0A969CB02DDDD1C400A3DF34 /* MLXAudio in Frameworks */ = {isa = PBXBuildFile; productRef = 0A969CAF2DDDD1C400A3DF34 /* MLXAudio */; };
 		0A969CB32DDDD25A00A3DF34 /* MLXLLM in Frameworks */ = {isa = PBXBuildFile; productRef = 0A969CB22DDDD25A00A3DF34 /* MLXLLM */; };
 		0A969CB52DDDD25A00A3DF34 /* MLXLMCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 0A969CB42DDDD25A00A3DF34 /* MLXLMCommon */; };
 /* End PBXBuildFile section */
@@ -31,7 +31,7 @@
 			files = (
 				0A969CB32DDDD25A00A3DF34 /* MLXLLM in Frameworks */,
 				0A969CB52DDDD25A00A3DF34 /* MLXLMCommon in Frameworks */,
-				0A969CB02DDDD1C400A3DF34 /* Swift-TTS in Frameworks */,
+				0A969CB02DDDD1C400A3DF34 /* MLXAudio in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -82,7 +82,7 @@
 			);
 			name = Ichi;
 			packageProductDependencies = (
-				0A969CAF2DDDD1C400A3DF34 /* Swift-TTS */,
+				0A969CAF2DDDD1C400A3DF34 /* MLXAudio */,
 				0A969CB22DDDD25A00A3DF34 /* MLXLLM */,
 				0A969CB42DDDD25A00A3DF34 /* MLXLMCommon */,
 			);
@@ -396,10 +396,10 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		0A969CAF2DDDD1C400A3DF34 /* Swift-TTS */ = {
+		0A969CAF2DDDD1C400A3DF34 /* MLXAudio */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 0A8B32782DDDCEAB00006081 /* XCRemoteSwiftPackageReference "mlx-audio" */;
-			productName = "Swift-TTS";
+			productName = MLXAudio;
 		};
 		0A969CB22DDDD25A00A3DF34 /* MLXLLM */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Ichi.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Ichi.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,21 +11,12 @@
       }
     },
     {
-      "identity" : "jinja",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/johnmai-dev/Jinja",
-      "state" : {
-        "revision" : "31c4dd39bcdc07eaa42a384bdc88ea599022b800",
-        "version" : "1.1.2"
-      }
-    },
-    {
       "identity" : "mlx-audio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/rudrankriyam/mlx-audio.git",
       "state" : {
         "branch" : "main",
-        "revision" : "29212622a81c0510311620227cb91792fb566a07"
+        "revision" : "60dffeb1d7d005faf0a253fe95ece18a92209280"
       }
     },
     {
@@ -33,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift",
       "state" : {
-        "revision" : "b94473af8c50010edba87a48bbd60c3d7f949852",
-        "version" : "0.25.4"
+        "revision" : "072b684acaae80b6a463abab3a103732f33774bf",
+        "version" : "0.29.1"
       }
     },
     {
@@ -43,16 +34,16 @@
       "location" : "https://github.com/rudrankriyam/mlx-swift-examples.git",
       "state" : {
         "branch" : "main",
-        "revision" : "b764dbd740e3aaa87eaf5fbee235cb15c7c846d5"
+        "revision" : "5f1e32b1576a65d02d7a11797868b03dba21f1d3"
       }
     },
     {
-      "identity" : "swift-argument-parser",
+      "identity" : "swift-asn1",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "0fbc8848e389af3bb55c182bc19ca9d5dc2f255b",
-        "version" : "1.4.0"
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
       }
     },
     {
@@ -62,6 +53,24 @@
       "state" : {
         "revision" : "c1805596154bb3a265fd91b8ac0c4433b4348fb0",
         "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "swift-jinja",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-jinja.git",
+      "state" : {
+        "revision" : "0b67ecb79139f6addef8699eff3622808aa6c7dc",
+        "version" : "2.3.6"
       }
     },
     {
@@ -78,8 +87,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers",
       "state" : {
-        "revision" : "940a4fac109d7d68817b22382de4894a8ea945c3",
-        "version" : "0.1.20"
+        "revision" : "150169bfba0889c229a2ce7494cf8949f18e6906",
+        "version" : "1.1.9"
+      }
+    },
+    {
+      "identity" : "yyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ibireme/yyjson.git",
+      "state" : {
+        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
+        "version" : "0.12.0"
       }
     }
   ],

--- a/Ichi/ConversationConformances.swift
+++ b/Ichi/ConversationConformances.swift
@@ -1,0 +1,3 @@
+extension SpeechRecognizer: SpeechRecognizing {}
+extension OnDeviceProcessor: ConversationalResponding {}
+extension TTSManager: SpeechOutputting {}

--- a/Ichi/ConversationInterfaces.swift
+++ b/Ichi/ConversationInterfaces.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+@MainActor
+protocol SpeechRecognizing: AnyObject {
+  var transcribedText: String { get }
+  var errorMessage: String? { get }
+
+  func requestAuthorization() async -> Bool
+  func startListening() async
+  func stopListening()
+  func reset()
+}
+
+@MainActor
+protocol ConversationalResponding: AnyObject {
+  var generatedResponse: String { get }
+
+  func processTranscribedText(_ text: String) async
+  func cancelProcessing()
+}
+
+@MainActor
+protocol SpeechOutputting: AnyObject {
+  var isAudioPlaying: Bool { get }
+
+  func say(_ text: String, voice: String?, speed: Float)
+  func stopPlayback()
+}

--- a/Ichi/IchiApp.swift
+++ b/Ichi/IchiApp.swift
@@ -15,7 +15,7 @@ struct IchiApp: App {
     var body: some Scene {
         WindowGroup {
             if hasCompletedOnboarding {
-                MainView()
+                MainView(processor: processor)
                     .environment(processor)
             } else {
                 OnboardingView(hasCompletedOnboarding: $hasCompletedOnboarding)

--- a/Ichi/KokoroTTSProvider.swift
+++ b/Ichi/KokoroTTSProvider.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Swift_TTS
+import MLXAudio
 import MLX
 import Combine
 import os.log

--- a/Ichi/MainView.swift
+++ b/Ichi/MainView.swift
@@ -1,6 +1,4 @@
-import Speech
 import SwiftUI
-import os.log
 
 struct TypewriterView: View {
   let state: AppState
@@ -88,108 +86,22 @@ struct SpeakingView: View {
 }
 
 struct MainView: View {
-  @State private var currentState: AppState = .idle
+  @State private var conversation: VoiceConversationController
+  @State private var ttsManager: TTSManager
   @State private var buttonScale: CGFloat = 1.0
-  @State private var transcriptText: String = ""
   @State private var showingSettings = false
   @Environment(\.colorScheme) private var colorScheme
 
-  // Text-to-speech manager
-  @State private var ttsManager = TTSManager()
-
-  // Logger for TTS functionality
-  private let ttsLogger = Logger(
-    subsystem: Bundle.main.bundleIdentifier ?? "com.rudrankriyam.ichi", category: "TextToSpeech")
-
-  // Speech recognizer and processor
-  @State private var speechRecognizer = SpeechRecognizer()
-  @State private var onDeviceProcessor = OnDeviceProcessor()
-
-  // Handle speech recognition state transitions
-  private func handleSpeechRecognition() async {
-    switch currentState {
-    case .idle:
-      // Start listening
-      currentState = .listening
-      await speechRecognizer.startListening()
-
-    case .listening:
-      // Stop listening and start transcribing
-      currentState = .transcribing
-      Task { @MainActor in
-        speechRecognizer.stopListening()
-        transcriptText = speechRecognizer.transcribedText
-
-        // Move to processing after a short delay
-        currentState = .processing
-        await onDeviceProcessor.processTranscribedText(speechRecognizer.transcribedText)
-
-        currentState = .playing
-        // Speak the response using Kokoro TTS
-        ttsLogger.info("Starting text-to-speech for generated response")
-        speakResponse(onDeviceProcessor.generatedResponse)
-      }
-
-    case .transcribing:
-      currentState = .processing
-      await onDeviceProcessor.processTranscribedText(speechRecognizer.transcribedText)
-    case .processing:
-      // Skip to playing
-      ttsLogger.info("Transitioning from processing to playing state")
-      transcriptText = onDeviceProcessor.generatedResponse
-      currentState = .playing
-      // Speak the response using Kokoro TTS
-      ttsLogger.info("Starting text-to-speech for generated response")
-      speakResponse(onDeviceProcessor.generatedResponse)
-
-    case .playing:
-      // Reset to idle
-      ttsLogger.info("Transitioning from playing to idle state")
-      currentState = .idle
-      speechRecognizer.reset()
-      onDeviceProcessor.cancelProcessing()
-
-      // Stop any ongoing TTS playback
-      ttsLogger.info("Stopping TTS playback")
-      ttsManager.stopPlayback()
-    case .error:
-      // Reset to idle
-      currentState = .idle
-      speechRecognizer.reset()
-      onDeviceProcessor.cancelProcessing()
-    }
-
-    updateTranscriptText()
-  }
-
-  // Update transcript text based on speech recognizer state
-  private func updateTranscriptText() {
-    switch currentState {
-    case .idle:
-      transcriptText = "Tap the button to start a conversation"
-    case .listening:
-      if !speechRecognizer.transcribedText.isEmpty {
-        transcriptText = speechRecognizer.transcribedText
-      } else {
-        transcriptText = "Listening to your voice..."
-      }
-    case .transcribing:
-      transcriptText = "Converting your speech to text..."
-    case .processing:
-      transcriptText = "Thinking about your request..."
-    case .playing:
-      transcriptText = "Here's what I found for you..."
-    case .error:
-      transcriptText = "An error occurred, please try again."
-    }
-  }
-
-  // Function to speak the response using Kokoro TTS
-  private func speakResponse(_ text: String) {
-    ttsLogger.info(
-      "Starting text-to-speech process for response of length: \(text.count) characters")
-    ttsLogger.debug("Calling ttsManager.say() with text input")
-    ttsManager.say(text, speed: 1.0)
+  init(processor: OnDeviceProcessor) {
+    let ttsManager = TTSManager()
+    _ttsManager = State(initialValue: ttsManager)
+    _conversation = State(
+      initialValue: VoiceConversationController(
+        speechRecognizer: SpeechRecognizer(),
+        responder: processor,
+        speechOutput: ttsManager
+      )
+    )
   }
 
   var backgroundGradient: LinearGradient {
@@ -197,7 +109,7 @@ struct MainView: View {
       gradient: Gradient(colors: [
         colorScheme == .dark ? Color.black : Color.white,
         colorScheme == .dark ? Color.black.opacity(0.8) : Color.white.opacity(0.8),
-        currentState.tertiaryColor,
+        conversation.state.tertiaryColor,
       ]),
       startPoint: .top,
       endPoint: .bottom
@@ -228,17 +140,17 @@ struct MainView: View {
         .padding(.top, 10)
         // Status area
         VStack(spacing: 16) {
-          Image(systemName: currentState.SFSymbolName)
+          Image(systemName: conversation.state.SFSymbolName)
             .font(.system(size: 36, weight: .light))
-            .foregroundColor(currentState.color)
+            .foregroundColor(conversation.state.color)
             .frame(width: 80, height: 80)
             .background(
               ZStack {
                 Circle()
-                  .fill(currentState.secondaryColor)
-                if currentState != .idle {
+                  .fill(conversation.state.secondaryColor)
+                if conversation.state != .idle {
                   PulsatingCircle(
-                    color: currentState.tertiaryColor,
+                    color: conversation.state.tertiaryColor,
                     startRadius: 80,
                     endRadius: 120
                   )
@@ -247,19 +159,19 @@ struct MainView: View {
             )
             .overlay(
               Circle()
-                .stroke(currentState.color.opacity(0.3), lineWidth: 1)
+                .stroke(conversation.state.color.opacity(0.3), lineWidth: 1)
             )
 
-          Text(currentState.description)
+          Text(conversation.state.description)
             .font(.system(size: 20, weight: .medium, design: .rounded))
-            .foregroundColor(currentState.color)
+            .foregroundColor(conversation.state.color)
 
           // State-specific animation views
           Group {
-            WaveformView(state: currentState)
-            TypewriterView(state: currentState)
-            ProcessingView(state: currentState)
-            SpeakingView(state: currentState)
+            WaveformView(state: conversation.state)
+            TypewriterView(state: conversation.state)
+            ProcessingView(state: conversation.state)
+            SpeakingView(state: conversation.state)
           }
           .frame(height: 30)
         }
@@ -271,16 +183,16 @@ struct MainView: View {
             .foregroundColor(.secondary)
             .padding(.leading, 4)
 
-          Text(transcriptText)
+          Text(conversation.transcriptText)
             .font(.system(size: 16, weight: .regular, design: .rounded))
             .foregroundColor(.primary)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(16)
             .overlay(
               RoundedRectangle(cornerRadius: 12)
-                .stroke(currentState.color.opacity(0.2), lineWidth: 1)
+                .stroke(conversation.state.color.opacity(0.2), lineWidth: 1)
             )
-            .animation(.easeInOut, value: transcriptText)
+            .animation(.easeInOut, value: conversation.transcriptText)
         }
         .frame(maxWidth: .infinity)
         .padding(.horizontal, 24)
@@ -307,7 +219,7 @@ struct MainView: View {
           }
 
           Task {
-            await handleSpeechRecognition()
+            await conversation.handlePrimaryAction()
           }
         }) {
           ZStack {
@@ -316,20 +228,20 @@ struct MainView: View {
               .fill(.ultraThinMaterial)
               .overlay(
                 Circle()
-                  .stroke(currentState.color, lineWidth: 2)
+                  .stroke(conversation.state.color, lineWidth: 2)
               )
-              .shadow(color: currentState.color.opacity(0.3), radius: 10, x: 0, y: 5)
+              .shadow(color: conversation.state.color.opacity(0.3), radius: 10, x: 0, y: 5)
               .frame(width: 80, height: 80)
 
             // Button icon
-            Image(systemName: currentState == .idle ? "mic.fill" : "stop.fill")
+            Image(systemName: conversation.state == .idle ? "mic.fill" : "stop.fill")
               .font(.system(size: 30, weight: .medium))
-              .foregroundColor(currentState.color)
+              .foregroundColor(conversation.state.color)
 
             // Pulsating effect when active
-            if currentState != .idle {
+            if conversation.state != .idle {
               Circle()
-                .stroke(currentState.color.opacity(0.5), lineWidth: 2)
+                .stroke(conversation.state.color.opacity(0.5), lineWidth: 2)
                 .frame(width: 90, height: 90)
                 .scaleEffect(buttonScale)
             }
@@ -342,28 +254,8 @@ struct MainView: View {
       .padding(.horizontal)
     }
     .onAppear {
-      updateTranscriptText()
-
       Task {
-        _ = await speechRecognizer.requestAuthorization()
-      }
-    }
-    .onChange(of: speechRecognizer.transcribedText) { _, newValue in
-      if currentState == .listening && !newValue.isEmpty {
-        transcriptText = newValue
-      }
-    }
-    .onChange(of: onDeviceProcessor.generatedResponse) { _, newValue in
-      if currentState == .processing && !newValue.isEmpty {
-        transcriptText = newValue
-      }
-    }
-    .onChange(of: ttsManager.isAudioPlaying) { _, isPlaying in
-      if !isPlaying && currentState == .playing {
-        ttsLogger.info("TTS playback completed, transitioning to idle state")
-        currentState = .idle
-      } else if isPlaying {
-        ttsLogger.info("TTS playback started")
+        await conversation.requestSpeechAuthorization()
       }
     }
     .sheet(isPresented: $showingSettings) {

--- a/Ichi/OnDeviceProcessor.swift
+++ b/Ichi/OnDeviceProcessor.swift
@@ -11,6 +11,7 @@ import MLXRandom
 import SwiftUI
 
 /// A class that handles on-device processing for conversational AI
+@MainActor
 @Observable
 final class OnDeviceProcessor {
   // MARK: - Properties
@@ -22,8 +23,11 @@ final class OnDeviceProcessor {
   var modelInfo = ""
 
   // Configuration properties
-  let modelConfiguration = LLMRegistry.qwen3_1_7b_4bit
-  let generateParameters = GenerateParameters(maxTokens: 240, temperature: 0.6)
+  let configuration: OnDeviceProcessorConfiguration
+
+  init(configuration: OnDeviceProcessorConfiguration = .ichiDefault) {
+    self.configuration = configuration
+  }
 
   // MARK: - Model Loading
 
@@ -35,7 +39,6 @@ final class OnDeviceProcessor {
   private var loadState = LoadState.idle
 
   /// Loads the model if not already loaded
-  @MainActor
   func loadModel() async throws -> ModelContainer {
     switch loadState {
     case .idle:
@@ -43,11 +46,11 @@ final class OnDeviceProcessor {
       MLX.GPU.set(cacheLimit: 20 * 1024 * 1024)
 
       let modelContainer = try await LLMModelFactory.shared.loadContainer(
-        configuration: modelConfiguration
-      ) { [modelConfiguration] progress in
+        configuration: configuration.model
+      ) { [configuration] progress in
         Task { @MainActor in
           self.modelInfo =
-            "Downloading \(modelConfiguration.name): \(Int(progress.fractionCompleted * 100))%"
+            "Downloading \(configuration.model.name): \(Int(progress.fractionCompleted * 100))%"
         }
       }
 
@@ -62,7 +65,6 @@ final class OnDeviceProcessor {
   // MARK: - Processing Methods
 
   /// Process the transcribed text and generate a response
-  @MainActor
   func processTranscribedText(_ text: String) async {
     guard !isProcessing else { return }
 
@@ -75,15 +77,14 @@ final class OnDeviceProcessor {
   }
 
   /// Generate a response for the given input text
-  @MainActor
   private func generateResponse(for text: String) async {
     let chat: [Chat.Message] = [
-      .system("You are a helpful assistant. Keep your answers short."),
+      .system(configuration.systemPrompt),
       .user(text),
     ]
 
     let userInput = UserInput(
-      chat: chat, additionalContext: ["enable_thinking": false])
+      chat: chat, additionalContext: ["enable_thinking": configuration.enableThinking])
 
     do {
       let modelContainer = try await loadModel()
@@ -94,7 +95,7 @@ final class OnDeviceProcessor {
       try await modelContainer.perform { (context: ModelContext) -> Void in
         let lmInput = try await context.processor.prepare(input: userInput)
         let stream = try MLXLMCommon.generate(
-          input: lmInput, parameters: generateParameters, context: context)
+          input: lmInput, parameters: configuration.generateParameters, context: context)
 
         // Generate and output in batches
         for await output in stream {
@@ -111,8 +112,21 @@ final class OnDeviceProcessor {
   }
 
   /// Cancel the current processing task
-  @MainActor
   func cancelProcessing() {
     isProcessing = false
   }
+}
+
+struct OnDeviceProcessorConfiguration: Sendable {
+  let model: ModelConfiguration
+  let systemPrompt: String
+  let generateParameters: GenerateParameters
+  let enableThinking: Bool
+
+  static let ichiDefault = OnDeviceProcessorConfiguration(
+    model: LLMRegistry.qwen3_1_7b_4bit,
+    systemPrompt: "You are a helpful assistant. Keep your answers short.",
+    generateParameters: GenerateParameters(maxTokens: 240, temperature: 0.6),
+    enableThinking: false
+  )
 }

--- a/Ichi/SpeechRecognizer.swift
+++ b/Ichi/SpeechRecognizer.swift
@@ -14,8 +14,9 @@ import os
   import AVFoundation
 #endif
 
+@MainActor
 @Observable
-final class SpeechRecognizer: NSObject, SFSpeechRecognizerDelegate {
+final class SpeechRecognizer: NSObject, @preconcurrency SFSpeechRecognizerDelegate {
 
   // State properties
   var isListening = false
@@ -200,7 +201,6 @@ final class SpeechRecognizer: NSObject, SFSpeechRecognizerDelegate {
   // MARK: - Speech Recognition Methods
 
   /// Start listening and transcribing speech
-  @MainActor
   func startListening() async {
     logger.log("Attempting to start listening.")
     // Check if already listening
@@ -375,7 +375,7 @@ final class SpeechRecognizer: NSObject, SFSpeechRecognizerDelegate {
             if self.consecutiveErrors < 2 {
               Task { @MainActor in
                 self.reset()
-                try? await Task.sleep(nanoseconds: 1_000_000_000)  // 1 second delay
+                try? await Task.sleep(for: .seconds(1))
                 await self.startListening()
               }
               return
@@ -430,7 +430,6 @@ final class SpeechRecognizer: NSObject, SFSpeechRecognizerDelegate {
   }
 
   /// Stop listening and finalize transcription
-  @MainActor
   func stopListening() {
     logger.log("Stop listening requested.")
     // Stop audio engine and recognition
@@ -448,7 +447,6 @@ final class SpeechRecognizer: NSObject, SFSpeechRecognizerDelegate {
   }
 
   /// Reset the recognizer state
-  @MainActor
   func reset() {
     logger.log("Resetting SpeechRecognizer state.")
     // Cancel any ongoing tasks

--- a/Ichi/TTSManager.swift
+++ b/Ichi/TTSManager.swift
@@ -2,8 +2,9 @@ import SwiftUI
 import Combine
 import os.log
 
+@MainActor
 @Observable
-class TTSManager {
+final class TTSManager {
     var currentEngine: TTSEngine = .kokoro {
         didSet {
             if currentEngine != oldValue {

--- a/Ichi/VoiceConversationController.swift
+++ b/Ichi/VoiceConversationController.swift
@@ -54,7 +54,10 @@ final class VoiceConversationController {
     case .listening:
       await finishListeningAndRespond()
 
-    case .transcribing, .processing, .playing, .error:
+    case .processing:
+      stopProcessingAndSpeakGeneratedResponse()
+
+    case .transcribing, .playing, .error:
       resetConversation()
     }
   }
@@ -125,6 +128,19 @@ final class VoiceConversationController {
     logger.info("Starting text-to-speech for generated response")
     speechOutput.say(text, voice: nil, speed: 1.0)
     startPlaybackMonitor(runID: runID)
+  }
+
+  private func stopProcessingAndSpeakGeneratedResponse() {
+    let response = responder.generatedResponse.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !response.isEmpty else {
+      resetConversation()
+      return
+    }
+
+    beginNewRun()
+    let runID = activeRunID
+    responder.cancelProcessing()
+    speak(response, runID: runID)
   }
 
   private func resetConversation(message: String? = nil) {

--- a/Ichi/VoiceConversationController.swift
+++ b/Ichi/VoiceConversationController.swift
@@ -112,6 +112,7 @@ final class VoiceConversationController {
   }
 
   private func speak(_ text: String, runID: UUID) {
+    stopMirroringDependencyText()
     state = .playing
     transcriptText = text
     logger.info("Starting text-to-speech for generated response")
@@ -173,6 +174,7 @@ final class VoiceConversationController {
 
     playbackTask = Task { @MainActor [weak self] in
       var playbackStarted = false
+      var hasCheckedPlayback = false
 
       while !Task.isCancelled {
         guard let self, self.activeRunID == runID, self.state == .playing else {
@@ -181,12 +183,13 @@ final class VoiceConversationController {
 
         if self.speechOutput.isAudioPlaying {
           playbackStarted = true
-        } else if playbackStarted {
+        } else if playbackStarted || hasCheckedPlayback {
           self.state = .idle
           self.updateTranscriptText()
           return
         }
 
+        hasCheckedPlayback = true
         try? await Task.sleep(for: .milliseconds(150))
       }
     }

--- a/Ichi/VoiceConversationController.swift
+++ b/Ichi/VoiceConversationController.swift
@@ -11,6 +11,8 @@ final class VoiceConversationController {
   @ObservationIgnored private let speechRecognizer: any SpeechRecognizing
   @ObservationIgnored private let responder: any ConversationalResponding
   @ObservationIgnored private let speechOutput: any SpeechOutputting
+  @ObservationIgnored private let playbackPollInterval: Duration
+  @ObservationIgnored private let playbackStartTimeout: Duration
   @ObservationIgnored private let logger = Logger(
     subsystem: Bundle.main.bundleIdentifier ?? "com.rudrankriyam.ichi",
     category: "VoiceConversation"
@@ -23,11 +25,15 @@ final class VoiceConversationController {
   init(
     speechRecognizer: any SpeechRecognizing,
     responder: any ConversationalResponding,
-    speechOutput: any SpeechOutputting
+    speechOutput: any SpeechOutputting,
+    playbackPollInterval: Duration = .milliseconds(150),
+    playbackStartTimeout: Duration = .seconds(10)
   ) {
     self.speechRecognizer = speechRecognizer
     self.responder = responder
     self.speechOutput = speechOutput
+    self.playbackPollInterval = playbackPollInterval
+    self.playbackStartTimeout = playbackStartTimeout
     updateTranscriptText()
   }
 
@@ -103,6 +109,7 @@ final class VoiceConversationController {
 
     let response = responder.generatedResponse.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !response.isEmpty else {
+      stopMirroringDependencyText()
       state = .error
       transcriptText = "No response was generated. Please try again."
       return
@@ -174,7 +181,8 @@ final class VoiceConversationController {
 
     playbackTask = Task { @MainActor [weak self] in
       var playbackStarted = false
-      var hasCheckedPlayback = false
+      let clock = ContinuousClock()
+      let startDeadline = clock.now + (self?.playbackStartTimeout ?? .seconds(10))
 
       while !Task.isCancelled {
         guard let self, self.activeRunID == runID, self.state == .playing else {
@@ -183,14 +191,13 @@ final class VoiceConversationController {
 
         if self.speechOutput.isAudioPlaying {
           playbackStarted = true
-        } else if playbackStarted || hasCheckedPlayback {
+        } else if playbackStarted || clock.now >= startDeadline {
           self.state = .idle
           self.updateTranscriptText()
           return
         }
 
-        hasCheckedPlayback = true
-        try? await Task.sleep(for: .milliseconds(150))
+        try? await Task.sleep(for: self.playbackPollInterval)
       }
     }
   }

--- a/Ichi/VoiceConversationController.swift
+++ b/Ichi/VoiceConversationController.swift
@@ -1,0 +1,194 @@
+import Foundation
+import Observation
+import os
+
+@MainActor
+@Observable
+final class VoiceConversationController {
+  var state: AppState = .idle
+  var transcriptText = ""
+
+  @ObservationIgnored private let speechRecognizer: any SpeechRecognizing
+  @ObservationIgnored private let responder: any ConversationalResponding
+  @ObservationIgnored private let speechOutput: any SpeechOutputting
+  @ObservationIgnored private let logger = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "com.rudrankriyam.ichi",
+    category: "VoiceConversation"
+  )
+
+  @ObservationIgnored private var mirrorTask: Task<Void, Never>?
+  @ObservationIgnored private var playbackTask: Task<Void, Never>?
+  @ObservationIgnored private var activeRunID = UUID()
+
+  init(
+    speechRecognizer: any SpeechRecognizing,
+    responder: any ConversationalResponding,
+    speechOutput: any SpeechOutputting
+  ) {
+    self.speechRecognizer = speechRecognizer
+    self.responder = responder
+    self.speechOutput = speechOutput
+    updateTranscriptText()
+  }
+
+  deinit {
+    mirrorTask?.cancel()
+    playbackTask?.cancel()
+  }
+
+  func requestSpeechAuthorization() async {
+    _ = await speechRecognizer.requestAuthorization()
+  }
+
+  func handlePrimaryAction() async {
+    switch state {
+    case .idle:
+      await startListening()
+
+    case .listening:
+      await finishListeningAndRespond()
+
+    case .transcribing, .processing, .playing, .error:
+      resetConversation()
+    }
+  }
+
+  func refreshTranscriptFromDependencies() {
+    switch state {
+    case .listening:
+      let recognizedText = speechRecognizer.transcribedText
+      transcriptText = recognizedText.isEmpty ? "Listening to your voice..." : recognizedText
+
+    case .processing:
+      let generatedResponse = responder.generatedResponse
+      transcriptText = generatedResponse.isEmpty ? "Thinking about your request..." : generatedResponse
+
+    default:
+      updateTranscriptText()
+    }
+  }
+
+  private func startListening() async {
+    beginNewRun()
+    state = .listening
+    updateTranscriptText()
+    startMirroringDependencyText()
+
+    await speechRecognizer.startListening()
+
+    if speechRecognizer.errorMessage != nil {
+      state = .error
+      updateTranscriptText()
+      stopMirroringDependencyText()
+    }
+  }
+
+  private func finishListeningAndRespond() async {
+    state = .transcribing
+    updateTranscriptText()
+    speechRecognizer.stopListening()
+
+    let requestText = speechRecognizer.transcribedText.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !requestText.isEmpty else {
+      resetConversation(message: "I didn't catch that. Tap the button to try again.")
+      return
+    }
+
+    let runID = activeRunID
+    state = .processing
+    updateTranscriptText()
+
+    await responder.processTranscribedText(requestText)
+    guard activeRunID == runID, !Task.isCancelled else { return }
+
+    let response = responder.generatedResponse.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !response.isEmpty else {
+      state = .error
+      transcriptText = "No response was generated. Please try again."
+      return
+    }
+
+    speak(response, runID: runID)
+  }
+
+  private func speak(_ text: String, runID: UUID) {
+    state = .playing
+    transcriptText = text
+    logger.info("Starting text-to-speech for generated response")
+    speechOutput.say(text, voice: nil, speed: 1.0)
+    startPlaybackMonitor(runID: runID)
+  }
+
+  private func resetConversation(message: String? = nil) {
+    beginNewRun()
+    speechRecognizer.reset()
+    responder.cancelProcessing()
+    speechOutput.stopPlayback()
+    state = .idle
+    transcriptText = message ?? "Tap the button to start a conversation"
+  }
+
+  private func beginNewRun() {
+    activeRunID = UUID()
+    stopMirroringDependencyText()
+    playbackTask?.cancel()
+    playbackTask = nil
+  }
+
+  private func updateTranscriptText() {
+    switch state {
+    case .idle:
+      transcriptText = "Tap the button to start a conversation"
+    case .listening:
+      transcriptText = "Listening to your voice..."
+    case .transcribing:
+      transcriptText = "Converting your speech to text..."
+    case .processing:
+      transcriptText = "Thinking about your request..."
+    case .playing:
+      transcriptText = "Here's what I found for you..."
+    case .error:
+      transcriptText = speechRecognizer.errorMessage ?? "An error occurred, please try again."
+    }
+  }
+
+  private func startMirroringDependencyText() {
+    stopMirroringDependencyText()
+
+    mirrorTask = Task { @MainActor [weak self] in
+      while !Task.isCancelled {
+        self?.refreshTranscriptFromDependencies()
+        try? await Task.sleep(for: .milliseconds(120))
+      }
+    }
+  }
+
+  private func stopMirroringDependencyText() {
+    mirrorTask?.cancel()
+    mirrorTask = nil
+  }
+
+  private func startPlaybackMonitor(runID: UUID) {
+    playbackTask?.cancel()
+
+    playbackTask = Task { @MainActor [weak self] in
+      var playbackStarted = false
+
+      while !Task.isCancelled {
+        guard let self, self.activeRunID == runID, self.state == .playing else {
+          return
+        }
+
+        if self.speechOutput.isAudioPlaying {
+          playbackStarted = true
+        } else if playbackStarted {
+          self.state = .idle
+          self.updateTranscriptText()
+          return
+        }
+
+        try? await Task.sleep(for: .milliseconds(150))
+      }
+    }
+  }
+}

--- a/IchiConversationTests/VoiceConversationControllerTests.swift
+++ b/IchiConversationTests/VoiceConversationControllerTests.swift
@@ -128,6 +128,32 @@ struct VoiceConversationControllerTests {
     #expect(testRig.speaker.spokenTexts.isEmpty)
   }
 
+  @Test("primary action during processing speaks partial response")
+  func primaryActionDuringProcessingSpeaksPartialResponse() async {
+    let testRig = makeController()
+    testRig.recognizer.transcribedText = "Tell me something slow"
+    testRig.responder.response = "The final response should not replace the partial."
+    testRig.responder.shouldWaitForRelease = true
+
+    await testRig.controller.handlePrimaryAction()
+
+    let processingTask = Task {
+      await testRig.controller.handlePrimaryAction()
+    }
+
+    await testRig.responder.waitUntilSuspended()
+    testRig.responder.generatedResponse = "Here is the partial response."
+
+    await testRig.controller.handlePrimaryAction()
+    testRig.responder.release()
+    await processingTask.value
+
+    #expect(testRig.controller.state == .playing)
+    #expect(testRig.responder.cancelCallCount == 1)
+    #expect(testRig.speaker.spokenTexts == ["Here is the partial response."])
+    #expect(testRig.controller.transcriptText == "Here is the partial response.")
+  }
+
   private func makeController(
     playbackPollInterval: Duration = .milliseconds(150),
     playbackStartTimeout: Duration = .seconds(10)

--- a/IchiConversationTests/VoiceConversationControllerTests.swift
+++ b/IchiConversationTests/VoiceConversationControllerTests.swift
@@ -53,9 +53,31 @@ struct VoiceConversationControllerTests {
     #expect(testRig.controller.transcriptText == "The generated response should stay visible.")
   }
 
-  @Test("short playback returns to idle")
-  func shortPlaybackReturnsToIdle() async {
-    let testRig = makeController()
+  @Test("delayed playback start keeps playing state")
+  func delayedPlaybackStartKeepsPlayingState() async {
+    let testRig = makeController(playbackPollInterval: .milliseconds(30), playbackStartTimeout: .milliseconds(300))
+    testRig.recognizer.transcribedText = "Say something after synthesizing"
+    testRig.responder.response = "Starting soon."
+    testRig.speaker.startsPlayingOnSay = false
+    testRig.speaker.startPlaybackAfter = .milliseconds(120)
+
+    await testRig.controller.handlePrimaryAction()
+    await testRig.controller.handlePrimaryAction()
+    try? await Task.sleep(for: .milliseconds(90))
+
+    #expect(testRig.controller.state == .playing)
+    #expect(testRig.controller.transcriptText == "Starting soon.")
+
+    try? await Task.sleep(for: .milliseconds(80))
+    testRig.speaker.isAudioPlaying = false
+    try? await Task.sleep(for: .milliseconds(60))
+
+    #expect(testRig.controller.state == .idle)
+  }
+
+  @Test("playback that never starts returns to idle")
+  func playbackThatNeverStartsReturnsToIdle() async {
+    let testRig = makeController(playbackPollInterval: .milliseconds(30), playbackStartTimeout: .milliseconds(120))
     testRig.recognizer.transcribedText = "Say something quick"
     testRig.responder.response = "Done."
     testRig.speaker.startsPlayingOnSay = false
@@ -66,6 +88,20 @@ struct VoiceConversationControllerTests {
 
     #expect(testRig.controller.state == .idle)
     #expect(testRig.controller.transcriptText == "Tap the button to start a conversation")
+  }
+
+  @Test("empty generated response keeps its error message")
+  func emptyGeneratedResponseKeepsErrorMessage() async {
+    let testRig = makeController()
+    testRig.recognizer.transcribedText = "Say nothing"
+    testRig.responder.response = ""
+
+    await testRig.controller.handlePrimaryAction()
+    await testRig.controller.handlePrimaryAction()
+    try? await Task.sleep(for: .milliseconds(180))
+
+    #expect(testRig.controller.state == .error)
+    #expect(testRig.controller.transcriptText == "No response was generated. Please try again.")
   }
 
   @Test("reset during processing prevents stale speech")
@@ -92,14 +128,19 @@ struct VoiceConversationControllerTests {
     #expect(testRig.speaker.spokenTexts.isEmpty)
   }
 
-  private func makeController() -> TestRig {
+  private func makeController(
+    playbackPollInterval: Duration = .milliseconds(150),
+    playbackStartTimeout: Duration = .seconds(10)
+  ) -> TestRig {
     let recognizer = FakeSpeechRecognizer()
     let responder = FakeResponder()
     let speaker = FakeSpeechOutput()
     let controller = VoiceConversationController(
       speechRecognizer: recognizer,
       responder: responder,
-      speechOutput: speaker
+      speechOutput: speaker,
+      playbackPollInterval: playbackPollInterval,
+      playbackStartTimeout: playbackStartTimeout
     )
 
     return TestRig(
@@ -196,11 +237,19 @@ private final class FakeSpeechOutput: SpeechOutputting {
   var isAudioPlaying = false
   var spokenTexts: [String] = []
   var startsPlayingOnSay = true
+  var startPlaybackAfter: Duration?
   var stopCallCount = 0
 
   func say(_ text: String, voice: String?, speed: Float) {
     spokenTexts.append(text)
     isAudioPlaying = startsPlayingOnSay
+
+    if let startPlaybackAfter {
+      Task { @MainActor in
+        try? await Task.sleep(for: startPlaybackAfter)
+        isAudioPlaying = true
+      }
+    }
   }
 
   func stopPlayback() {

--- a/IchiConversationTests/VoiceConversationControllerTests.swift
+++ b/IchiConversationTests/VoiceConversationControllerTests.swift
@@ -39,6 +39,35 @@ struct VoiceConversationControllerTests {
     #expect(testRig.controller.transcriptText == "A small voice agent builder.")
   }
 
+  @Test("keeps the generated response visible while playing")
+  func generatedResponseStaysVisibleWhilePlaying() async {
+    let testRig = makeController()
+    testRig.recognizer.transcribedText = "What should stay on screen?"
+    testRig.responder.response = "The generated response should stay visible."
+
+    await testRig.controller.handlePrimaryAction()
+    await testRig.controller.handlePrimaryAction()
+    try? await Task.sleep(for: .milliseconds(180))
+
+    #expect(testRig.controller.state == .playing)
+    #expect(testRig.controller.transcriptText == "The generated response should stay visible.")
+  }
+
+  @Test("short playback returns to idle")
+  func shortPlaybackReturnsToIdle() async {
+    let testRig = makeController()
+    testRig.recognizer.transcribedText = "Say something quick"
+    testRig.responder.response = "Done."
+    testRig.speaker.startsPlayingOnSay = false
+
+    await testRig.controller.handlePrimaryAction()
+    await testRig.controller.handlePrimaryAction()
+    try? await Task.sleep(for: .milliseconds(180))
+
+    #expect(testRig.controller.state == .idle)
+    #expect(testRig.controller.transcriptText == "Tap the button to start a conversation")
+  }
+
   @Test("reset during processing prevents stale speech")
   func resetDuringProcessingPreventsStaleSpeech() async {
     let testRig = makeController()
@@ -166,11 +195,12 @@ private final class FakeResponder: ConversationalResponding {
 private final class FakeSpeechOutput: SpeechOutputting {
   var isAudioPlaying = false
   var spokenTexts: [String] = []
+  var startsPlayingOnSay = true
   var stopCallCount = 0
 
   func say(_ text: String, voice: String?, speed: Float) {
     spokenTexts.append(text)
-    isAudioPlaying = true
+    isAudioPlaying = startsPlayingOnSay
   }
 
   func stopPlayback() {

--- a/IchiConversationTests/VoiceConversationControllerTests.swift
+++ b/IchiConversationTests/VoiceConversationControllerTests.swift
@@ -1,0 +1,180 @@
+import Testing
+@testable import IchiConversation
+
+@MainActor
+@Suite("Voice conversation controller")
+struct VoiceConversationControllerTests {
+  @Test("starts in idle with a helpful prompt")
+  func initialState() {
+    let controller = makeController().controller
+
+    #expect(controller.state == .idle)
+    #expect(controller.transcriptText == "Tap the button to start a conversation")
+  }
+
+  @Test("starts listening from idle")
+  func startsListening() async {
+    let testRig = makeController()
+
+    await testRig.controller.handlePrimaryAction()
+
+    #expect(testRig.controller.state == .listening)
+    #expect(testRig.recognizer.startCallCount == 1)
+    #expect(testRig.controller.transcriptText == "Listening to your voice...")
+  }
+
+  @Test("turns a transcript into speech")
+  func respondsToTranscript() async {
+    let testRig = makeController()
+    testRig.recognizer.transcribedText = "What can I build today?"
+    testRig.responder.response = "A small voice agent builder."
+
+    await testRig.controller.handlePrimaryAction()
+    await testRig.controller.handlePrimaryAction()
+
+    #expect(testRig.recognizer.stopCallCount == 1)
+    #expect(testRig.responder.processedText == "What can I build today?")
+    #expect(testRig.speaker.spokenTexts == ["A small voice agent builder."])
+    #expect(testRig.controller.state == .playing)
+    #expect(testRig.controller.transcriptText == "A small voice agent builder.")
+  }
+
+  @Test("reset during processing prevents stale speech")
+  func resetDuringProcessingPreventsStaleSpeech() async {
+    let testRig = makeController()
+    testRig.recognizer.transcribedText = "Tell me something slow"
+    testRig.responder.response = "This should not be spoken."
+    testRig.responder.shouldWaitForRelease = true
+
+    await testRig.controller.handlePrimaryAction()
+
+    let processingTask = Task {
+      await testRig.controller.handlePrimaryAction()
+    }
+
+    await testRig.responder.waitUntilSuspended()
+    await testRig.controller.handlePrimaryAction()
+    testRig.responder.release()
+    await processingTask.value
+
+    #expect(testRig.controller.state == .idle)
+    #expect(testRig.responder.cancelCallCount == 1)
+    #expect(testRig.speaker.stopCallCount == 1)
+    #expect(testRig.speaker.spokenTexts.isEmpty)
+  }
+
+  private func makeController() -> TestRig {
+    let recognizer = FakeSpeechRecognizer()
+    let responder = FakeResponder()
+    let speaker = FakeSpeechOutput()
+    let controller = VoiceConversationController(
+      speechRecognizer: recognizer,
+      responder: responder,
+      speechOutput: speaker
+    )
+
+    return TestRig(
+      controller: controller,
+      recognizer: recognizer,
+      responder: responder,
+      speaker: speaker
+    )
+  }
+}
+
+@MainActor
+private struct TestRig {
+  let controller: VoiceConversationController
+  let recognizer: FakeSpeechRecognizer
+  let responder: FakeResponder
+  let speaker: FakeSpeechOutput
+}
+
+@MainActor
+private final class FakeSpeechRecognizer: SpeechRecognizing {
+  var transcribedText = ""
+  var errorMessage: String?
+  var startCallCount = 0
+  var stopCallCount = 0
+  var resetCallCount = 0
+
+  func requestAuthorization() async -> Bool {
+    true
+  }
+
+  func startListening() async {
+    startCallCount += 1
+  }
+
+  func stopListening() {
+    stopCallCount += 1
+  }
+
+  func reset() {
+    resetCallCount += 1
+    transcribedText = ""
+    errorMessage = nil
+  }
+}
+
+@MainActor
+private final class FakeResponder: ConversationalResponding {
+  var generatedResponse = ""
+  var response = "Response"
+  var processedText: String?
+  var cancelCallCount = 0
+  var shouldWaitForRelease = false
+
+  private var suspendedContinuation: CheckedContinuation<Void, Never>?
+  private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+  func processTranscribedText(_ text: String) async {
+    processedText = text
+
+    if shouldWaitForRelease {
+      await withCheckedContinuation { continuation in
+        releaseContinuation = continuation
+        suspendedContinuation?.resume()
+        suspendedContinuation = nil
+      }
+    }
+
+    generatedResponse = response
+  }
+
+  func cancelProcessing() {
+    cancelCallCount += 1
+  }
+
+  func waitUntilSuspended() async {
+    if releaseContinuation != nil {
+      return
+    }
+
+    await withCheckedContinuation { continuation in
+      suspendedContinuation = continuation
+    }
+  }
+
+  func release() {
+    releaseContinuation?.resume()
+    releaseContinuation = nil
+  }
+}
+
+@MainActor
+private final class FakeSpeechOutput: SpeechOutputting {
+  var isAudioPlaying = false
+  var spokenTexts: [String] = []
+  var stopCallCount = 0
+
+  func say(_ text: String, voice: String?, speed: Float) {
+    spokenTexts.append(text)
+    isAudioPlaying = true
+  }
+
+  func stopPlayback() {
+    stopCallCount += 1
+    isAudioPlaying = false
+  }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,45 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+  name: "IchiConversation",
+  platforms: [
+    .macOS(.v15)
+  ],
+  products: [
+    .library(name: "IchiConversation", targets: ["IchiConversation"])
+  ],
+  targets: [
+    .target(
+      name: "IchiConversation",
+      path: "Ichi",
+      exclude: [
+        "Assets.xcassets",
+        "AVSpeechTTSProvider.swift",
+        "ConversationConformances.swift",
+        "Ichi.entitlements",
+        "IchiApp.swift",
+        "KokoroTTSProvider.swift",
+        "MainView.swift",
+        "OnDeviceProcessor.swift",
+        "OnboardingView.swift",
+        "SettingsView.swift",
+        "SpeechRecognizer.swift",
+        "TTSManager.swift",
+        "TTSProtocol.swift",
+        "Views",
+      ],
+      sources: [
+        "AppState.swift",
+        "ConversationInterfaces.swift",
+        "VoiceConversationController.swift",
+      ]
+    ),
+    .testTarget(
+      name: "IchiConversationTests",
+      dependencies: ["IchiConversation"],
+      path: "IchiConversationTests"
+    ),
+  ]
+)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Last September, using online providers for speech-to-speech was expensive, and I
 - **Conversational AI**: Powered by on-device LLMs (Qwen model)
 - **Speech Recognition**: Real-time speech-to-text conversion
 - **Text-to-Speech**: Natural voice synthesis using Kokoro TTS
-- **Cross-Platform**: Supports iOS, macOS, and visionOS
+- **Apple Platform UI**: SwiftUI app shell, currently validated on macOS while the MLX audio stack evolves
 - **Beautiful UI**: Modern SwiftUI interface with smooth animations
 - **Onboarding**: Guided setup with model downloads
 


### PR DESCRIPTION
## Summary
- Extract the voice conversation flow out of MainView into a testable controller
- Add speech/responder/output interfaces while preserving the current MLX + Kokoro implementation
- Refresh MLXAudio package/product references and add focused controller tests

## Validation
- swift test
- xcodebuild -project Ichi.xcodeproj -scheme Ichi -destination 'platform=macOS,arch=arm64' -derivedDataPath ./build/IchiBuild CODE_SIGNING_ALLOWED=NO build

## Notes
- SwiftPM still warns about the mlx-swift-examples identity conflict between the transitive upstream dependency and the direct Rudrank fork. I left that intact because switching the direct dependency upstream reintroduces the Swift Transformers version conflict.