### PR TITLE
Require on-device speech recognition

### DIFF
--- a/Ichi/SpeechRecognitionRequestFactory.swift
+++ b/Ichi/SpeechRecognitionRequestFactory.swift
@@ -1,0 +1,10 @@
+import Speech
+
+enum SpeechRecognitionRequestFactory {
+  static func makeAudioBufferRecognitionRequest() -> SFSpeechAudioBufferRecognitionRequest {
+    let request = SFSpeechAudioBufferRecognitionRequest()
+    request.requiresOnDeviceRecognition = true
+    request.shouldReportPartialResults = true
+    return request
+  }
+}

--- a/Ichi/SpeechRecognizer.swift
+++ b/Ichi/SpeechRecognizer.swift
@@ -226,6 +226,13 @@ final class SpeechRecognizer: NSObject, @preconcurrency SFSpeechRecognizerDelega
       return
     }
 
+    guard speechRecognizer.supportsOnDeviceRecognition else {
+      logger.error("On-device speech recognition not available. Cannot start listening.")
+      recognitionState = .error
+      errorMessage = "On-device speech recognition is not available for the current language or device."
+      return
+    }
+
     do {
       logger.log("Configuring audio session and recognition request.")
       // Configure audio session
@@ -239,7 +246,7 @@ final class SpeechRecognizer: NSObject, @preconcurrency SFSpeechRecognizerDelega
       }
 
       // Create and configure the speech recognition request
-      recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
+      recognitionRequest = SpeechRecognitionRequestFactory.makeAudioBufferRecognitionRequest()
       guard let recognitionRequest = recognitionRequest else {
         logger.critical("Unable to create SFSpeechAudioBufferRecognitionRequest.")
         throw NSError(
@@ -247,8 +254,7 @@ final class SpeechRecognizer: NSObject, @preconcurrency SFSpeechRecognizerDelega
           userInfo: [NSLocalizedDescriptionKey: "Unable to create recognition request"])
       }
 
-      recognitionRequest.shouldReportPartialResults = true
-      logger.log("Recognition request configured for partial results.")
+      logger.log("Recognition request configured for on-device partial results.")
 
       // Configure audio input
       let inputNode = audioEngine.inputNode

--- a/IchiConversationTests/SpeechRecognitionRequestFactoryTests.swift
+++ b/IchiConversationTests/SpeechRecognitionRequestFactoryTests.swift
@@ -1,0 +1,13 @@
+import Testing
+@testable import IchiConversation
+
+@Suite("Speech recognition request factory")
+struct SpeechRecognitionRequestFactoryTests {
+  @Test("requires on-device recognition")
+  func requiresOnDeviceRecognition() {
+    let request = SpeechRecognitionRequestFactory.makeAudioBufferRecognitionRequest()
+
+    #expect(request.requiresOnDeviceRecognition)
+    #expect(request.shouldReportPartialResults)
+  }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -33,6 +33,7 @@ let package = Package(
       sources: [
         "AppState.swift",
         "ConversationInterfaces.swift",
+        "SpeechRecognitionRequestFactory.swift",
         "VoiceConversationController.swift",
       ]
     ),


### PR DESCRIPTION
## Summary
- require on-device speech recognition before starting the live recognizer
- centralize `SFSpeechAudioBufferRecognitionRequest` setup so requests always set `requiresOnDeviceRecognition = true`
- add a focused Swift package test that asserts the privacy-critical request flags

## Tests
- `swift package test` via XcodeBuildMCP: 10 passed
- `swift package build --target IchiConversation` via XcodeBuildMCP
- `xcodebuild -project Ichi.xcodeproj -scheme Ichi -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build`

## Notes
- A normal signed macOS build without `CODE_SIGNING_ALLOWED=NO` still stops on local provisioning: no Mac App Development profile for `com.rudrankriyam.Ichi`.
