### PR TITLE
Fix concurrency and correctness issues from audit

### DIFF
--- a/Ichi/ConversationInterfaces.swift
+++ b/Ichi/ConversationInterfaces.swift
@@ -14,6 +14,7 @@ protocol SpeechRecognizing: AnyObject {
 @MainActor
 protocol ConversationalResponding: AnyObject {
   var generatedResponse: String { get }
+  var processingError: String? { get }
 
   func processTranscribedText(_ text: String) async
   func cancelProcessing()

--- a/Ichi/OnDeviceProcessor.swift
+++ b/Ichi/OnDeviceProcessor.swift
@@ -20,10 +20,15 @@ final class OnDeviceProcessor {
   var isProcessing = false
   var transcribedText = ""
   var generatedResponse = ""
+  var processingError: String? = nil
   var modelInfo = ""
 
   // Configuration properties
   let configuration: OnDeviceProcessorConfiguration
+
+  // Generation lifecycle
+  @ObservationIgnored private var generationTask: Task<Void, Never>?
+  @ObservationIgnored private var activeGenerationID = UUID()
 
   init(configuration: OnDeviceProcessorConfiguration = .ichiDefault) {
     self.configuration = configuration
@@ -70,14 +75,29 @@ final class OnDeviceProcessor {
 
     self.transcribedText = text
     self.generatedResponse = ""
+    self.processingError = nil
 
+    let generationID = UUID()
+    activeGenerationID = generationID
     isProcessing = true
-    await generateResponse(for: text)
-    isProcessing = false
+
+    let task = Task { [weak self] in
+      guard let self else { return }
+      await self.generateResponse(for: text, generationID: generationID)
+    }
+    generationTask = task
+    await task.value
+
+    // Only the run that is still current may flip the processing flag back;
+    // a cancelled run must not clobber the state of a newer run.
+    if activeGenerationID == generationID {
+      isProcessing = false
+      generationTask = nil
+    }
   }
 
   /// Generate a response for the given input text
-  private func generateResponse(for text: String) async {
+  private func generateResponse(for text: String, generationID: UUID) async {
     let chat: [Chat.Message] = [
       .system(configuration.systemPrompt),
       .user(text),
@@ -92,27 +112,57 @@ final class OnDeviceProcessor {
       // Set a random seed for generation
       MLXRandom.seed(UInt64(Date.timeIntervalSinceReferenceDate * 1000))
 
-      try await modelContainer.perform { (context: ModelContext) -> Void in
-        let lmInput = try await context.processor.prepare(input: userInput)
-        let stream = try MLXLMCommon.generate(
-          input: lmInput, parameters: configuration.generateParameters, context: context)
+      // Token chunks are funneled through a single AsyncStream consumed by one
+      // MainActor task, so appends happen exactly in generation order.
+      let (chunks, chunkContinuation) = AsyncStream.makeStream(of: String.self)
 
-        // Generate and output in batches
-        for await output in stream {
-          if let chunk = output.chunk {
-            Task { @MainActor [chunk] in
-              self.generatedResponse += chunk
+      let consumer = Task { @MainActor [weak self] in
+        for await chunk in chunks {
+          guard let self, self.activeGenerationID == generationID else { return }
+          self.generatedResponse += chunk
+        }
+      }
+
+      var generationError: Error?
+      do {
+        try await modelContainer.perform { (context: ModelContext) -> Void in
+          let lmInput = try await context.processor.prepare(input: userInput)
+          let stream = try MLXLMCommon.generate(
+            input: lmInput, parameters: configuration.generateParameters, context: context)
+
+          // Generate and output in batches, stopping as soon as the run is cancelled.
+          for await output in stream {
+            if Task.isCancelled { break }
+            if let chunk = output.chunk {
+              chunkContinuation.yield(chunk)
             }
           }
         }
+      } catch {
+        generationError = error
       }
+
+      chunkContinuation.finish()
+      await consumer.value
+
+      if let generationError {
+        throw generationError
+      }
+    } catch is CancellationError {
+      // Cancelled runs end silently; the UI state is handled by the caller.
     } catch {
-      generatedResponse = "Failed: \(error)"
+      // Route errors to a dedicated property instead of the response text so
+      // downstream consumers (like TTS) never speak raw error descriptions.
+      guard activeGenerationID == generationID else { return }
+      processingError = error.localizedDescription
     }
   }
 
   /// Cancel the current processing task
   func cancelProcessing() {
+    activeGenerationID = UUID()
+    generationTask?.cancel()
+    generationTask = nil
     isProcessing = false
   }
 }

--- a/Ichi/SpeechRecognizer.swift
+++ b/Ichi/SpeechRecognizer.swift
@@ -333,64 +333,10 @@ final class SpeechRecognizer: NSObject, @preconcurrency SFSpeechRecognizerDelega
         }
 
         if let error = error {
-          self.logger.error("Recognition task error: \(error.localizedDescription)")
-          // Enhanced error logging
-          let nsError = error as NSError
-          self.logger.error("Detailed Error - Domain: \(nsError.domain), Code: \(nsError.code), UserInfo: \(nsError.userInfo)")
-
-          // Track consecutive errors to prevent infinite loops
-          let now = Date()
-          if let lastError = self.lastErrorTime, now.timeIntervalSince(lastError) < self.errorCooldownInterval {
-            self.consecutiveErrors += 1
-          } else {
-            self.consecutiveErrors = 1
-          }
-          self.lastErrorTime = now
-          
-          // If we've had too many consecutive errors, stop trying
-          if self.consecutiveErrors >= self.maxConsecutiveErrors {
-            self.logger.critical("Too many consecutive errors (\(self.consecutiveErrors)). Stopping speech recognition to prevent infinite loop.")
-            Task { @MainActor in
-              self.reset()
-              self.errorMessage = "Speech recognition has encountered repeated errors. Please restart the app or check your system permissions."
-              self.recognitionState = .error
-            }
-            return
-          }
-
-          if nsError.domain == "kAFAssistantErrorDomain" && nsError.code == 1101 {
-            self.logger.critical("CRITICAL: Received 1101 error. This indicates a failure in the speech recording client. Check microphone access and audio configuration.")
-            
-            // For error 1101, provide specific guidance but don't retry automatically
-            Task { @MainActor in
-              self.reset()
-              #if os(macOS)
-              self.errorMessage = "Microphone access denied. Please go to System Settings > Privacy & Security > Microphone and allow access for this app, then restart the app."
-              #else
-              self.errorMessage = "Microphone access issue detected. Please check your system permissions in Settings > Privacy & Security."
-              #endif
-              self.recognitionState = .error
-            }
-            return
-          }
-          
-          // Handle specific error cases
-          if nsError.domain == "kAFAssistantErrorDomain" && nsError.code == 203 {
-            self.logger.warning("Received kAFAssistantErrorDomain code 203. Retrying...")
-            // Only retry if we haven't had too many errors
-            if self.consecutiveErrors < 2 {
-              Task { @MainActor in
-                self.reset()
-                try? await Task.sleep(for: .seconds(1))
-                await self.startListening()
-              }
-              return
-            }
-          }
-
+          // Hop to the MainActor before touching any recognizer state; this
+          // callback arrives on an arbitrary queue.
           Task { @MainActor in
-            self.errorMessage = "Recognition error: \(error.localizedDescription)"
-            self.recognitionState = .error
+            self.handleRecognitionError(error)
           }
         }
 
@@ -433,6 +379,64 @@ final class SpeechRecognizer: NSObject, @preconcurrency SFSpeechRecognizerDelega
       recognitionTask = nil
       isListening = false
     }
+  }
+
+  /// Handle a recognition task error on the MainActor, tracking consecutive
+  /// errors and updating published state. Must only be called on the MainActor.
+  private func handleRecognitionError(_ error: Error) {
+    logger.error("Recognition task error: \(error.localizedDescription)")
+    // Enhanced error logging
+    let nsError = error as NSError
+    logger.error("Detailed Error - Domain: \(nsError.domain), Code: \(nsError.code), UserInfo: \(nsError.userInfo)")
+
+    // Track consecutive errors to prevent infinite loops
+    let now = Date()
+    if let lastError = lastErrorTime, now.timeIntervalSince(lastError) < errorCooldownInterval {
+      consecutiveErrors += 1
+    } else {
+      consecutiveErrors = 1
+    }
+    lastErrorTime = now
+
+    // If we've had too many consecutive errors, stop trying
+    if consecutiveErrors >= maxConsecutiveErrors {
+      logger.critical("Too many consecutive errors (\(self.consecutiveErrors)). Stopping speech recognition to prevent infinite loop.")
+      reset()
+      errorMessage = "Speech recognition has encountered repeated errors. Please restart the app or check your system permissions."
+      recognitionState = .error
+      return
+    }
+
+    if nsError.domain == "kAFAssistantErrorDomain" && nsError.code == 1101 {
+      logger.critical("CRITICAL: Received 1101 error. This indicates a failure in the speech recording client. Check microphone access and audio configuration.")
+
+      // For error 1101, provide specific guidance but don't retry automatically
+      reset()
+      #if os(macOS)
+        errorMessage = "Microphone access denied. Please go to System Settings > Privacy & Security > Microphone and allow access for this app, then restart the app."
+      #else
+        errorMessage = "Microphone access issue detected. Please check your system permissions in Settings > Privacy & Security."
+      #endif
+      recognitionState = .error
+      return
+    }
+
+    // Handle specific error cases
+    if nsError.domain == "kAFAssistantErrorDomain" && nsError.code == 203 {
+      logger.warning("Received kAFAssistantErrorDomain code 203. Retrying...")
+      // Only retry if we haven't had too many errors
+      if consecutiveErrors < 2 {
+        Task { @MainActor in
+          self.reset()
+          try? await Task.sleep(for: .seconds(1))
+          await self.startListening()
+        }
+        return
+      }
+    }
+
+    errorMessage = "Recognition error: \(error.localizedDescription)"
+    recognitionState = .error
   }
 
   /// Stop listening and finalize transcription

--- a/Ichi/VoiceConversationController.swift
+++ b/Ichi/VoiceConversationController.swift
@@ -110,6 +110,14 @@ final class VoiceConversationController {
     await responder.processTranscribedText(requestText)
     guard activeRunID == runID, !Task.isCancelled else { return }
 
+    if let processingError = responder.processingError {
+      logger.error("Response generation failed: \(processingError)")
+      stopMirroringDependencyText()
+      state = .error
+      transcriptText = "Response generation failed. Please try again."
+      return
+    }
+
     let response = responder.generatedResponse.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !response.isEmpty else {
       stopMirroringDependencyText()

--- a/IchiConversationTests/VoiceConversationControllerTests.swift
+++ b/IchiConversationTests/VoiceConversationControllerTests.swift
@@ -104,6 +104,21 @@ struct VoiceConversationControllerTests {
     #expect(testRig.controller.transcriptText == "No response was generated. Please try again.")
   }
 
+  @Test("error result is not spoken")
+  func errorResultIsNotSpoken() async {
+    let testRig = makeController()
+    testRig.recognizer.transcribedText = "Trigger a failure"
+    testRig.responder.response = "Failed: modelNotFound(underlying error)"
+    testRig.responder.errorToReport = "modelNotFound(underlying error)"
+
+    await testRig.controller.handlePrimaryAction()
+    await testRig.controller.handlePrimaryAction()
+
+    #expect(testRig.speaker.spokenTexts.isEmpty)
+    #expect(testRig.controller.state == .error)
+    #expect(testRig.controller.transcriptText == "Response generation failed. Please try again.")
+  }
+
   @Test("reset during processing prevents stale speech")
   func resetDuringProcessingPreventsStaleSpeech() async {
     let testRig = makeController()
@@ -216,7 +231,9 @@ private final class FakeSpeechRecognizer: SpeechRecognizing {
 @MainActor
 private final class FakeResponder: ConversationalResponding {
   var generatedResponse = ""
+  var processingError: String?
   var response = "Response"
+  var errorToReport: String?
   var processedText: String?
   var cancelCallCount = 0
   var shouldWaitForRelease = false
@@ -226,6 +243,7 @@ private final class FakeResponder: ConversationalResponding {
 
   func processTranscribedText(_ text: String) async {
     processedText = text
+    processingError = errorToReport
 
     if shouldWaitForRelease {
       await withCheckedContinuation { continuation in

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-Ichi is an experimental project that explores conversational AI capabilities across iOS, macOS, and visionOS. The project's name is inspired by a Japanese woman I met at a conference, who ignited the spark into coding again.
+Ichi is an experimental project that explores conversational AI capabilities on macOS (the only validated platform today), with iOS and visionOS as aspirational targets. The project's name is inspired by a Japanese woman I met at a conference, who ignited the spark into coding again.
 
 Last September, using online providers for speech-to-speech was expensive, and I wanted to take the on-device route instead. Local LLMs are still not there *yet*, but one day.
 


### PR DESCRIPTION
## Summary

Fixes five audited concurrency/correctness defects:

- **Real cancellation**: `OnDeviceProcessor.cancelProcessing()` previously only flipped `isProcessing`. It now holds the generation `Task` and cancels it; the MLX generate loop checks `Task.isCancelled` and stops. A per-run generation ID guarantees a cancelled run can no longer append to `generatedResponse` or clobber a newer run's state.
- **Errors are no longer spoken**: generation failures used to be written into `generatedResponse` (`"Failed: \(error)"`), which downstream TTS would speak aloud. Errors now go to a dedicated `processingError` property; `VoiceConversationController` surfaces them as an error state with a friendly message and never routes them to speech output. New controller test covers this.
- **Ordered streaming**: token chunks were appended via a fresh `Task { @MainActor }` per chunk, with no ordering guarantee. Chunks are now funneled through a single `AsyncStream` consumed by one MainActor task, so appends happen exactly in generation order.
- **SpeechRecognizer data race**: `consecutiveErrors` / `lastErrorTime` (and related error-handling state) were mutated directly from the recognition task callback, which arrives on an arbitrary queue. The error path now hops to the MainActor via an extracted `handleRecognitionError(_:)`, with identical behavior.
- **README**: platform claim aligned with reality — macOS is the validated platform; iOS/visionOS are aspirational.

## Testing

- `swift test`: 11 tests pass (10 baseline + 1 new controller test)
- Local `xcodebuild` of the macOS app (Xcode 27 beta): BUILD SUCCEEDED